### PR TITLE
Enable auto-resizing of images in posts

### DIFF
--- a/whiteboard/theme.css
+++ b/whiteboard/theme.css
@@ -329,4 +329,13 @@ body {
 	
 }
 
+/* Enable images in posts to automatically resize */
+/* as browser window changes sizes.               */
+
+.post-content img {
+  max-width: 100%;
+  height: auto;
+}
+
+
 /* Always remember to compress your live stylesheet and keep an uncompressed backup */


### PR DESCRIPTION
Added CSS to enable automatic resizing of images in posts as browser window size changes.

Signed-off-by: Michael Sheaver michael@michaelsheaver.com
