### PR TITLE
Fixing some warnings

### DIFF
--- a/whiteboard/comments.php
+++ b/whiteboard/comments.php
@@ -10,11 +10,12 @@
 	    <?php endif; ?>
 	<?php endif; ?>
 	
-	<?php $i++; ?> <!-- variable for alternating comment styles -->
+	<?php $i=0; ?> <!-- variable for alternating comment styles -->
 	<?php if($comments) : ?>
 		<h3><?php comments_number('No comments', 'One comment', '% comments'); ?></h3>
 	    <ol>
 	    <?php foreach($comments as $comment) : ?>
+		<?php $i++; ?>
 	    	<?php $comment_type = get_comment_type(); ?> <!-- checks for comment type -->
 	    	<?php if($comment_type == 'comment') { ?> <!-- outputs only comments -->
 		        <li id="comment-<?php comment_ID(); ?>" class="comment <?php if($i&1) { echo 'odd';} else {echo 'even';} ?> <?php $user_info = get_userdata(1); if ($user_info->ID == $comment->user_id) echo 'authorComment'; ?> <?php if ($comment->user_id > 0) echo 'user-comment'; ?>">

--- a/whiteboard/functions.php
+++ b/whiteboard/functions.php
@@ -63,7 +63,7 @@
 	}
 
 	// custom background support
-	add_custom_background();
+	add_theme_support('custom-background');
 
 	// custom header image support
 	define('NO_HEADER_TEXT', true );
@@ -79,7 +79,9 @@
 	        }
 	    </style><?php
 	}
-	add_custom_image_header( '', 'admin_header_style' );
+	add_theme_support('custom-header', array(
+		'admin-head-callback' => 'admin_header_style'
+	));
 
 	// adds Post Format support
 	// learn more: http://codex.wordpress.org/Post_Formats
@@ -100,7 +102,8 @@
 	function comment_count( $count ) {
 		if ( ! is_admin() ) {
 			global $id;
-			$comments_by_type = &separate_comments(get_comments('status=approve&post_id=' . $id));
+			$comments = get_comments('status=approve&postid=' . $id);
+			$comments_by_type = separate_comments($comments);
 			return count($comments_by_type['comment']);
 		} else {
 			return $count;


### PR DESCRIPTION
When I installed Whiteboard under the current Wordpress, a couple of warnings showed.  One of these warnings actually indicated a bug; comments all had the class 'odd', and none 'even' because of an error in the incrementing of $i.
